### PR TITLE
include stdint.h 

### DIFF
--- a/cmdlineopts.h
+++ b/cmdlineopts.h
@@ -7,8 +7,8 @@
 #ifndef CMDLINEOPTS_H
 #define CMDLINEOPTS_H
 
-#define VERSION_NUMBER	"1.3.3"
-#define RELEASE_DATE	" 6 Nov 2021"
+#define VERSION_NUMBER	"1.3.4"
+#define RELEASE_DATE	"24 Nov 2021"
 
 class CmdLineOpts {
   public:

--- a/datastructs.h
+++ b/datastructs.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <limits.h>
 #include <assert.h>
+#include <stdint.h>
 
 #ifndef DATASTRUCTS_H
 #define DATASTRUCTS_H


### PR DESCRIPTION
Trying to build ped-sim in a barebones minimal docker image (Alpine linux), having trouble compiling with musl libc (Alpine doesn't use glibc). Minimal changes to:

- `#include <stdint.h>` in datastructs.h
- bump version number and release date